### PR TITLE
add support for affiliation section

### DIFF
--- a/src/partials/affiliation.html
+++ b/src/partials/affiliation.html
@@ -1,0 +1,17 @@
+{{#section 'affiliation'}}
+<hr>
+<section class="row">
+  <h3 class="{{headerClass}}"><span class="fa fa-fw fa-child"></span>&nbsp;{{{sectionTitle "Affiliation"}}}</h3>
+  <div class="{{contentClass}}">
+    {{#each r.affiliation.history}}
+      {{#if url}}
+      <h4><strong>{{role}}</strong>, <a href="{{{url}}}">{{organization}}</a></h4>
+      {{else}}
+      <h4><strong>{{role}}</strong>, {{organization}}</h4>
+      {{/if}}
+    {{formatDate safe.start 'YYYY-MM'}}&mdash;{{formatDate safe.end 'YYYY-MM'}}
+    {{{summary}}}
+    {{/each}}
+  </div>
+</section>
+{{/section}}

--- a/src/partials/body.html
+++ b/src/partials/body.html
@@ -5,6 +5,7 @@
   {{> employment}}
   {{> projects}}
   {{> samples}}
+  {{> affiliation}}
   {{> education}}
   {{> service}}
   {{> writing}}


### PR DESCRIPTION
This PR adds support for the "affiliation" section in a FRESH formatted resume.

Here's an example of how it looks with the "flatly" theme using the test resume.json:

![image](https://user-images.githubusercontent.com/377603/30750034-28fcc75c-9f6a-11e7-8376-88494e6efb5e.png)
